### PR TITLE
added padding option to day-night icon

### DIFF
--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -35,6 +35,9 @@ abstract class DayNightSwitcherBaseWidget extends StatefulWidget {
   /// The craters color.
   final Color cratersColor;
 
+  /// The outer padding.
+  final EdgeInsets padding;
+
   /// Creates a new day / night switcher base widget instance.
   const DayNightSwitcherBaseWidget({
     required bool? isDarkModeEnabled,
@@ -47,6 +50,7 @@ abstract class DayNightSwitcherBaseWidget extends StatefulWidget {
     Color? starsColor,
     Color? cloudsColor,
     Color? cratersColor,
+    EdgeInsets? padding,
   })  : this.isDarkModeEnabled = isDarkModeEnabled ?? false,
         dayBackgroundColor = dayBackgroundColor ?? const Color(0xFF3498DB),
         nightBackgroundColor = nightBackgroundColor ?? const Color(0xFF192734),
@@ -54,16 +58,14 @@ abstract class DayNightSwitcherBaseWidget extends StatefulWidget {
         moonColor = moonColor ?? const Color(0xFFFFE5B5),
         starsColor = starsColor ?? Colors.white,
         cloudsColor = cloudsColor ?? Colors.white,
-        cratersColor = cratersColor ?? const Color(0xFFE8CDA5);
+        cratersColor = cratersColor ?? const Color(0xFFE8CDA5),
+        padding = padding ?? const EdgeInsets.symmetric(vertical: 12);
 
   /// The widget height.
   double get height => 36;
 
   /// The widget width.
   double get width;
-
-  /// The outer padding.
-  EdgeInsets get padding;
 
   /// Allows to have a copy of this instance with the given parameters.
   DayNightSwitcherBaseWidget copyWith({

--- a/lib/src/widgets.dart
+++ b/lib/src/widgets.dart
@@ -91,6 +91,7 @@ class DayNightSwitcherIcon extends DayNightSwitcherBaseWidget {
     Color? starsColor,
     Color? cloudsColor,
     Color? cratersColor,
+    EdgeInsets? padding,
   }) : super(
           isDarkModeEnabled: isDarkModeEnabled,
           onStateChanged: onStateChanged,
@@ -102,6 +103,7 @@ class DayNightSwitcherIcon extends DayNightSwitcherBaseWidget {
           starsColor: starsColor,
           cloudsColor: cloudsColor,
           cratersColor: cratersColor,
+          padding: padding
         );
 
   @override
@@ -109,9 +111,6 @@ class DayNightSwitcherIcon extends DayNightSwitcherBaseWidget {
 
   @override
   double get width => 36;
-
-  @override
-  EdgeInsets get padding => const EdgeInsets.symmetric(vertical: 12);
 
   @override
   DayNightSwitcherIcon copyWith({
@@ -125,6 +124,7 @@ class DayNightSwitcherIcon extends DayNightSwitcherBaseWidget {
     Color? starsColor,
     Color? cloudsColor,
     Color? cratersColor,
+    EdgeInsets? padding,
   }) =>
       DayNightSwitcherIcon(
         isDarkModeEnabled: isDarkModeEnabled ?? this.isDarkModeEnabled,
@@ -137,6 +137,7 @@ class DayNightSwitcherIcon extends DayNightSwitcherBaseWidget {
         starsColor: starsColor ?? this.starsColor,
         cloudsColor: cloudsColor ?? this.cloudsColor,
         cratersColor: cratersColor ?? this.cratersColor,
+        padding: padding ?? this.padding,
       );
 }
 


### PR DESCRIPTION
Hi!

Thank you for an awesome library!

I'd like to add a new option `padding` to `DayNightSwitcherIcon` initializer, Couldn't make it work with ListTile+CircleAvatar, here's the code snippet:
```dart
                          child: ListTile(
                            leading: CircleAvatar(
                              child: DayNightSwitcherIcon(
                                // padding: EdgeInsets.all(0), // <-- the new option
                                isDarkModeEnabled: darkModeOn,
                                onStateChanged: (isDarkModeEnabled) {
                                  setState(() {
                                    ...
                                  });
                                },
                              ),
                            ),
                            title: const Text(
                              'Day/night mode',
                              style: TextStyle(fontWeight: FontWeight.w600),
                            ),
                          ),

```
To compare:

When the padding is hardcoded in the lib code to EdgeInsets.symmetric(vertical: 10):
![Screenshot from 2023-03-20 00-54-14](https://user-images.githubusercontent.com/20026712/226216360-f8afc9a8-bc15-473e-aa20-a48ea0935b48.png)

When it's possible to set the padding, i.e. zero padding:
![Screenshot from 2023-03-20 00-53-47](https://user-images.githubusercontent.com/20026712/226216364-64cab59c-414d-4361-9b49-2d803fe8997b.png)
